### PR TITLE
Fixed issue with excel matching

### DIFF
--- a/src/sailsprep/BIDS_convertor.py
+++ b/src/sailsprep/BIDS_convertor.py
@@ -1012,7 +1012,7 @@ def process_single_video(
                     annotation_df["ID"].astype(str) == str(participant_id)
                 ]
                 mask = (
-                    participant_excel["FileName"].str.split(".").str[0]
+                    participant_excel["FileName"].str.rsplit(".", n=1).str[0]
                     == filename_without_extension
                 )
                 video_excel = participant_excel[mask]


### PR DESCRIPTION
This PR is to adress a tiny issue with the matching of the video being processed with its annotations from the csv file. Indeed, many video files have originally dots in their filename (like "28.03.2025.mp4"for example), so I needed to go from 

```                    
participant_excel["FileName"].str.split(".").str[0]
```             
to 
```             
participant_excel["FileName"].str.rsplit(".", n=1).str[0]
```      